### PR TITLE
Long delayed fixes and balance

### DIFF
--- a/Common/Defs/ThingDefs_Buildings/Buildings_Production.xml
+++ b/Common/Defs/ThingDefs_Buildings/Buildings_Production.xml
@@ -1,52 +1,53 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <Defs>
-  <ThingDef ParentName="ApiniBuildingBase">  <!-- Honey Capsule -->
-    <defName>HoneyCapsule</defName>
-    <label>honey capsule</label>
-    <thingClass>Apini.Building_FermentingVat</thingClass>
-	<modExtensions>
-		<li Class="Apini.VatProperties">
-      <inputThingDef>Nectar</inputThingDef>
-			<outputThingDef>ApiniHoney</outputThingDef>
-			<maxCapacity>200</maxCapacity>
-			<fermentationModifier>2</fermentationModifier>
-			<!-- 1:4 ratio -->
-			<inputToOutputRatio>10</inputToOutputRatio>
-			<!-- Translations, point to custom translation lines. -->
-			<containsInputTranslation>ContainsNectar</containsInputTranslation>
-			<containsOutputTranslation>ContainsHoney</containsOutputTranslation>
-			<fermentedTranslation>FermentedHoney</fermentedTranslation>
-			<fermentationProgressTranslation>HoneyFermentationProgress</fermentationProgressTranslation>
-			<fermentationNonIdealTranslation>HoneyFermentationBarrelOutOfIdealTemperature</fermentationNonIdealTranslation>
-		</li>
-	</modExtensions>
-    <graphicData>
-      <texPath>Things/Building/Capsules/HoneyCapsule</texPath>
-      <graphicClass>Graphic_Single</graphicClass>
-      <damageData>
-        <rect>(0.05,0.1,0.9,0.9)</rect>
-      </damageData>
-    </graphicData>
-    <minifiedDef>MinifiedThing</minifiedDef>
-    <altitudeLayer>Building</altitudeLayer>
-    <passability>PassThroughOnly</passability>
-    <fillPercent>0.45</fillPercent>
-    <pathCost>60</pathCost>
-    <building>
-    <isMealSource>true</isMealSource>
-    </building>
-    <statBases>
-      <WorkToBuild>600</WorkToBuild>
-      <Mass>10</Mass>
-      <MaxHitPoints>100</MaxHitPoints>
-      <Flammability>1.0</Flammability>
-    </statBases>
-    <description>A hexagonal container for creating honey from nectar.</description>
-    <costList>
-      <Pollen>20</Pollen>
-      <WoodLog>10</WoodLog>
-      <ApiniWax>30</ApiniWax>
-    </costList>
+	<ThingDef ParentName="ApiniBuildingBase">
+		<!-- Honey Capsule -->
+		<defName>HoneyCapsule</defName>
+		<label>honey capsule</label>
+		<thingClass>Apini.Building_FermentingVat</thingClass>
+		<modExtensions>
+			<li Class="Apini.VatProperties">
+				<inputThingDef>Nectar</inputThingDef>
+				<outputThingDef>ApiniHoney</outputThingDef>
+				<maxCapacity>200</maxCapacity>
+				<fermentationModifier>2</fermentationModifier>
+				<!-- 1:4 ratio -->
+				<inputToOutputRatio>10</inputToOutputRatio>
+				<!-- Translations, point to custom translation lines. -->
+				<containsInputTranslation>ContainsNectar</containsInputTranslation>
+				<containsOutputTranslation>ContainsHoney</containsOutputTranslation>
+				<fermentedTranslation>FermentedHoney</fermentedTranslation>
+				<fermentationProgressTranslation>HoneyFermentationProgress</fermentationProgressTranslation>
+				<fermentationNonIdealTranslation>HoneyFermentationBarrelOutOfIdealTemperature</fermentationNonIdealTranslation>
+			</li>
+		</modExtensions>
+		<graphicData>
+			<texPath>Things/Building/Capsules/HoneyCapsule</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<damageData>
+				<rect>(0.05,0.1,0.9,0.9)</rect>
+			</damageData>
+		</graphicData>
+		<minifiedDef>MinifiedThing</minifiedDef>
+		<altitudeLayer>Building</altitudeLayer>
+		<passability>PassThroughOnly</passability>
+		<fillPercent>0.45</fillPercent>
+		<pathCost>60</pathCost>
+		<building>
+			<isMealSource>true</isMealSource>
+		</building>
+		<statBases>
+			<WorkToBuild>600</WorkToBuild>
+			<Mass>10</Mass>
+			<MaxHitPoints>100</MaxHitPoints>
+			<Flammability>1.0</Flammability>
+		</statBases>
+		<description>A hexagonal container for creating honey from nectar.</description>
+		<costList>
+			<Pollen>20</Pollen>
+			<WoodLog>10</WoodLog>
+			<ApiniWax>30</ApiniWax>
+		</costList>
 		<comps>
 			<li Class="CompProperties_Forbiddable"/>
 			<li Class="CompProperties_TemperatureRuinable">
@@ -55,13 +56,13 @@
 				<maxSafeTemperature>60</maxSafeTemperature>
 			</li>
 		</comps>
-    <tickerType>Rare</tickerType>
-    <rotatable>true</rotatable>
-    <designationCategory>Apitecture</designationCategory>
-    <constructEffect>ConstructWood</constructEffect>
-  </ThingDef>
-
-	<ThingDef ParentName="ApiniBuildingBase">  <!-- Nectar Still -->
+		<tickerType>Rare</tickerType>
+		<rotatable>true</rotatable>
+		<designationCategory>Apitecture</designationCategory>
+		<constructEffect>ConstructWood</constructEffect>
+	</ThingDef>
+	<ThingDef ParentName="ApiniBuildingBase">
+		<!-- Nectar Still -->
 		<defName>ApiniNectarStill</defName>
 		<label>Apini Nectar Still</label>
 		<thingClass>Building_WorkTable</thingClass>
@@ -111,12 +112,12 @@
 			<spawnedConceptLearnOpportunity>BillsTab</spawnedConceptLearnOpportunity>
 		</building>
 		<comps>
-			  <li Class="CompProperties_Facility">
+			<li Class="CompProperties_Facility">
 				<statOffsets>
 					<WorkTableWorkSpeedFactor>0.25</WorkTableWorkSpeedFactor>
 				</statOffsets>
 				<maxSimultaneous>6</maxSimultaneous>
-			  </li>
+			</li>
 			<li Class="CompProperties_AffectedByFacilities">
 				<linkableFacilities>
 					<li>ToolCabinet</li>
@@ -132,8 +133,8 @@
 			<li>PlaceWorker_ShowFacilitiesConnections</li>
 		</placeWorkers>
 	</ThingDef>
-  
-	<ThingDef ParentName="ApiniBuildingBase">  <!-- Prosthetics Table -->
+	<ThingDef ParentName="ApiniBuildingBase">
+		<!-- Prosthetics Table -->
 		<defName>ApiniProstheticsTable</defName>
 		<label>Apini Prosthetics Table</label>
 		<thingClass>Building_WorkTable</thingClass>
@@ -150,7 +151,9 @@
 				<cornerBR>Damage/Corner</cornerBR>
 			</damageData>
 		</graphicData>
-		<researchPrerequisites><li>ApiniProstheticsTech</li></researchPrerequisites>
+		<researchPrerequisites>
+			<li>ApiniProstheticsTech</li>
+		</researchPrerequisites>
 		<castEdgeShadows>true</castEdgeShadows>
 		<staticSunShadowHeight>0.20</staticSunShadowHeight>
 		<size>(2,1)</size>
@@ -185,12 +188,12 @@
 			<spawnedConceptLearnOpportunity>BillsTab</spawnedConceptLearnOpportunity>
 		</building>
 		<comps>
-			  <li Class="CompProperties_Facility">
+			<li Class="CompProperties_Facility">
 				<statOffsets>
 					<WorkTableWorkSpeedFactor>0.25</WorkTableWorkSpeedFactor>
 				</statOffsets>
 				<maxSimultaneous>6</maxSimultaneous>
-			  </li>
+			</li>
 			<li Class="CompProperties_AffectedByFacilities">
 				<linkableFacilities>
 					<li>ToolCabinet</li>
@@ -206,8 +209,8 @@
 			<li>PlaceWorker_ShowFacilitiesConnections</li>
 		</placeWorkers>
 	</ThingDef>
-
-	<ThingDef ParentName="ApiniBuildingBase">  <!-- Apitech Table -->
+	<ThingDef ParentName="ApiniBuildingBase">
+		<!-- Apitech Table -->
 		<defName>ApitechTable</defName>
 		<label>Apitech Table</label>
 		<thingClass>Building_WorkTable</thingClass>
@@ -224,16 +227,17 @@
 				<cornerBR>Damage/Corner</cornerBR>
 			</damageData>
 		</graphicData>
-		<researchPrerequisites><li>Apitech</li></researchPrerequisites>
+		<researchPrerequisites>
+			<li>Apitech</li>
+		</researchPrerequisites>
 		<castEdgeShadows>true</castEdgeShadows>
 		<staticSunShadowHeight>0.20</staticSunShadowHeight>
 		<size>(3,1)</size>
-		<stuffCategories>
-			<li>Metallic</li>
-		</stuffCategories>
 		<costStuffCount>100</costStuffCount>
 		<costList>
 			<ApiniWax>80</ApiniWax>
+			<ComponentIndustrial>3</ComponentIndustrial>
+			<Steel>200</Steel>
 		</costList>
 		<altitudeLayer>Building</altitudeLayer>
 		<fillPercent>0.5</fillPercent>
@@ -257,12 +261,12 @@
 			<spawnedConceptLearnOpportunity>BillsTab</spawnedConceptLearnOpportunity>
 		</building>
 		<comps>
-			  <li Class="CompProperties_Facility">
+			<li Class="CompProperties_Facility">
 				<statOffsets>
 					<WorkTableWorkSpeedFactor>0.25</WorkTableWorkSpeedFactor>
 				</statOffsets>
 				<maxSimultaneous>6</maxSimultaneous>
-			  </li>
+			</li>
 			<li Class="CompProperties_AffectedByFacilities">
 				<linkableFacilities>
 					<li>ToolCabinet</li>
@@ -278,8 +282,8 @@
 			<li>PlaceWorker_ShowFacilitiesConnections</li>
 		</placeWorkers>
 	</ThingDef>
-
-	<ThingDef ParentName="ApiniBuildingBase">  <!-- Apitech Synthesizer -->
+	<ThingDef ParentName="ApiniBuildingBase">
+		<!-- Apitech Synthesizer -->
 		<defName>ApitechSynthesizer</defName>
 		<label>Apitech Synthesizer</label>
 		<thingClass>Building_WorkTable</thingClass>
@@ -297,14 +301,12 @@
 			</damageData>
 		</graphicData>
 		<rotatable>false</rotatable>
-		<researchPrerequisites><li>Apitech</li></researchPrerequisites>
+		<researchPrerequisites>
+			<li>Apitech</li>
+		</researchPrerequisites>
 		<castEdgeShadows>true</castEdgeShadows>
 		<staticSunShadowHeight>0.20</staticSunShadowHeight>
 		<size>(1,1)</size>
-		<stuffCategories>
-			<li>Metallic</li>
-		</stuffCategories>
-		<costStuffCount>50</costStuffCount>
 		<costList>
 			<ApiniWax>50</ApiniWax>
 			<Steel>200</Steel>
@@ -333,18 +335,18 @@
 			<spawnedConceptLearnOpportunity>BillsTab</spawnedConceptLearnOpportunity>
 		</building>
 		<comps>
-		  <li Class="CompProperties_Power">
-			<compClass>CompPowerTrader</compClass>
-      <shortCircuitInRain>true</shortCircuitInRain>
-			<basePowerConsumption>200</basePowerConsumption>
-		  </li>
-		  <li Class="CompProperties_Flickable"/>
-		  <li Class="CompProperties_Facility">
-			<statOffsets>
-				<WorkTableWorkSpeedFactor>0.25</WorkTableWorkSpeedFactor>
-			</statOffsets>
-			<maxSimultaneous>6</maxSimultaneous>
-		  </li>
+			<li Class="CompProperties_Power">
+				<compClass>CompPowerTrader</compClass>
+				<shortCircuitInRain>true</shortCircuitInRain>
+				<basePowerConsumption>200</basePowerConsumption>
+			</li>
+			<li Class="CompProperties_Flickable"/>
+			<li Class="CompProperties_Facility">
+				<statOffsets>
+					<WorkTableWorkSpeedFactor>0.25</WorkTableWorkSpeedFactor>
+				</statOffsets>
+				<maxSimultaneous>6</maxSimultaneous>
+			</li>
 			<li Class="CompProperties_AffectedByFacilities">
 				<linkableFacilities>
 					<li>ToolCabinet</li>
@@ -357,45 +359,46 @@
 		<placeWorkers>
 			<li>PlaceWorker_ShowFacilitiesConnections</li>
 		</placeWorkers>
-	</ThingDef> 
-	
-	<ThingDef Name="ApiniBuildingBase" ParentName="FurnitureBase" Abstract="True">  <!-- Apini Building Base -->
-    <designationCategory>Apitecture</designationCategory>
-    <researchPrerequisites>
-      <li>ApicultureBasics</li>
-    </researchPrerequisites>
-  </ThingDef>
-
-  <ThingDef Name="VatBase" ParentName="ApiniBuildingBase" Abstract="True">
-    <thingClass>Apini.Building_FermentingVat</thingClass>
-    <graphicData>
-      <texPath>Things/Building/Capsules/HoneyCapsule</texPath>
-      <graphicClass>Graphic_Single</graphicClass>
-      <damageData>
-        <rect>(0.05,0.1,0.9,0.9)</rect>
-      </damageData>
-    </graphicData>
-    <minifiedDef>MinifiedThing</minifiedDef>
-    <altitudeLayer>Building</altitudeLayer>
-    <passability>PassThroughOnly</passability>
-    <researchPrerequisites><li>HoneyRefining</li></researchPrerequisites>
-    <fillPercent>0.45</fillPercent>
-    <pathCost>60</pathCost>
-    <building>
-      <isMealSource>true</isMealSource>
+	</ThingDef>
+	<ThingDef Name="ApiniBuildingBase" ParentName="FurnitureBase" Abstract="True">
+		<!-- Apini Building Base -->
+		<designationCategory>Apitecture</designationCategory>
+		<researchPrerequisites>
+			<li>ApicultureBasics</li>
+		</researchPrerequisites>
+	</ThingDef>
+	<ThingDef Name="VatBase" ParentName="ApiniBuildingBase" Abstract="True">
+		<thingClass>Apini.Building_FermentingVat</thingClass>
+		<graphicData>
+			<texPath>Things/Building/Capsules/HoneyCapsule</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<damageData>
+				<rect>(0.05,0.1,0.9,0.9)</rect>
+			</damageData>
+		</graphicData>
+		<minifiedDef>MinifiedThing</minifiedDef>
+		<altitudeLayer>Building</altitudeLayer>
+		<passability>PassThroughOnly</passability>
+		<researchPrerequisites>
+			<li>HoneyRefining</li>
+		</researchPrerequisites>
+		<fillPercent>0.45</fillPercent>
+		<pathCost>60</pathCost>
+		<building>
+			<isMealSource>true</isMealSource>
 			<ai_chillDestination>false</ai_chillDestination>
-    </building>
-    <statBases>
-      <WorkToBuild>600</WorkToBuild>
-      <Mass>10</Mass>
-      <MaxHitPoints>100</MaxHitPoints>
-      <Flammability>1.0</Flammability>
-    </statBases>
-    <costList>
-      <Pollen>20</Pollen>
-      <WoodLog>10</WoodLog>
-      <ApiniWax>30</ApiniWax>
-    </costList>
+		</building>
+		<statBases>
+			<WorkToBuild>600</WorkToBuild>
+			<Mass>10</Mass>
+			<MaxHitPoints>100</MaxHitPoints>
+			<Flammability>1.0</Flammability>
+		</statBases>
+		<costList>
+			<Pollen>20</Pollen>
+			<WoodLog>10</WoodLog>
+			<ApiniWax>30</ApiniWax>
+		</costList>
 		<comps>
 			<li Class="CompProperties_Forbiddable"/>
 			<li Class="CompProperties_TemperatureRuinable">
@@ -404,256 +407,255 @@
 				<maxSafeTemperature>60</maxSafeTemperature>
 			</li>
 		</comps>
-    <tickerType>Rare</tickerType>
-    <rotatable>true</rotatable>
-    <constructEffect>ConstructWood</constructEffect>
-  </ThingDef>
-
-  <ThingDef ParentName="VatBase">  <!-- Honey Vat (Frostbell) -->
-    <defName>Vat_F</defName>
-    <label>Honey Capsule (Frostbell)</label>
-    <description>A hexagonal container for creating honey from nectar.</description>
-    <thingClass>Apini.Building_FermentingVat</thingClass>
-	<modExtensions>
-		<li Class="Apini.VatProperties">
-			<inputThingDef>Nectar_F</inputThingDef>
-			<outputThingDef>Honey_F</outputThingDef>
-			<maxCapacity>200</maxCapacity>
-			<fermentationModifier>3</fermentationModifier>
-			<!-- 1:4 ratio -->
-			<inputToOutputRatio>4</inputToOutputRatio>
-			<!-- Translations, point to custom translation lines. -->
-			<containsInputTranslation>ContainsNectar</containsInputTranslation>
-			<containsOutputTranslation>ContainsHoney</containsOutputTranslation>
-			<fermentedTranslation>FermentedHoney</fermentedTranslation>
-			<fermentationProgressTranslation>HoneyFermentationProgress</fermentationProgressTranslation>
-			<fermentationNonIdealTranslation>HoneyFermentationBarrelOutOfIdealTemperature</fermentationNonIdealTranslation>
-		</li>
-	</modExtensions>
-    <graphicData>
-      <texPath>Things/Building/Capsules/HoneyCapsule_Frostbell</texPath>
-    </graphicData>
-  </ThingDef>
-
-  <ThingDef ParentName="VatBase">  <!-- Honey Vat (Emberose) -->
-    <defName>Vat_E</defName>
-    <label>Honey Capsule (Emberose)</label>
-    <description>A hexagonal container for creating honey from nectar.</description>
-    <thingClass>Apini.Building_FermentingVat</thingClass>
-	<modExtensions>
-		<li Class="Apini.VatProperties">
-			<inputThingDef>Nectar_E</inputThingDef>
-			<outputThingDef>Honey_E</outputThingDef>
-			<maxCapacity>200</maxCapacity>
-			<fermentationModifier>3</fermentationModifier>
-			<!-- 1:4 ratio -->
-			<inputToOutputRatio>4</inputToOutputRatio>
-			<!-- Translations, point to custom translation lines. -->
-			<containsInputTranslation>ContainsNectar</containsInputTranslation>
-			<containsOutputTranslation>ContainsHoney</containsOutputTranslation>
-			<fermentedTranslation>FermentedHoney</fermentedTranslation>
-			<fermentationProgressTranslation>HoneyFermentationProgress</fermentationProgressTranslation>
-			<fermentationNonIdealTranslation>HoneyFermentationBarrelOutOfIdealTemperature</fermentationNonIdealTranslation>
-		</li>
-	</modExtensions>
-    <graphicData>
-      <texPath>Things/Building/Capsules/HoneyCapsule_Emberose</texPath>
-    </graphicData>
-  </ThingDef>
-
-  <ThingDef ParentName="VatBase">  <!-- Honey Vat (Metalily) -->
-    <defName>Vat_M</defName>
-    <label>Honey Capsule (Metalily)</label>
-    <description>A hexagonal container for creating honey from nectar.</description>
-    <thingClass>Apini.Building_FermentingVat</thingClass>
-	<modExtensions>
-		<li Class="Apini.VatProperties">
-			<inputThingDef>Nectar_M</inputThingDef>
-			<outputThingDef>Honey_M</outputThingDef>
-			<maxCapacity>200</maxCapacity>
-			<fermentationModifier>3</fermentationModifier>
-			<!-- 1:4 ratio -->
-			<inputToOutputRatio>4</inputToOutputRatio>
-			<!-- Translations, point to custom translation lines. -->
-			<containsInputTranslation>ContainsNectar</containsInputTranslation>
-			<containsOutputTranslation>ContainsHoney</containsOutputTranslation>
-			<fermentedTranslation>FermentedHoney</fermentedTranslation>
-			<fermentationProgressTranslation>HoneyFermentationProgress</fermentationProgressTranslation>
-			<fermentationNonIdealTranslation>HoneyFermentationBarrelOutOfIdealTemperature</fermentationNonIdealTranslation>
-		</li>
-	</modExtensions>
-    <graphicData>
-      <texPath>Things/Building/Capsules/HoneyCapsule_Metalily</texPath>
-    </graphicData>
-  </ThingDef>
-
-  <ThingDef ParentName="VatBase">  <!-- Honey Vat (Bardsong) -->
-    <defName>Vat_B</defName>
-    <label>Honey Capsule (Bardsong)</label>
-    <description>A hexagonal container for creating honey from nectar.</description>
-    <thingClass>Apini.Building_FermentingVat</thingClass>
-	<modExtensions>
-		<li Class="Apini.VatProperties">
-			<inputThingDef>Nectar_B</inputThingDef>
-			<outputThingDef>Honey_B</outputThingDef>
-			<maxCapacity>200</maxCapacity>
-			<fermentationModifier>3</fermentationModifier>
-			<!-- 1:4 ratio -->
-			<inputToOutputRatio>4</inputToOutputRatio>
-			<!-- Translations, point to custom translation lines. -->
-			<containsInputTranslation>ContainsNectar</containsInputTranslation>
-			<containsOutputTranslation>ContainsHoney</containsOutputTranslation>
-			<fermentedTranslation>FermentedHoney</fermentedTranslation>
-			<fermentationProgressTranslation>HoneyFermentationProgress</fermentationProgressTranslation>
-			<fermentationNonIdealTranslation>HoneyFermentationBarrelOutOfIdealTemperature</fermentationNonIdealTranslation>
-		</li>
-	</modExtensions>
-    <graphicData>
-      <texPath>Things/Building/Capsules/HoneyCapsule_Bardsong</texPath>
-    </graphicData>
-  </ThingDef>
-
-  <ThingDef ParentName="VatBase">  <!-- Honey Vat (Rushthorn) -->
-    <defName>Vat_R</defName>
-    <label>Honey Capsule (Rushthorn)</label>
-    <description>A hexagonal container for creating honey from nectar.</description>
-    <thingClass>Apini.Building_FermentingVat</thingClass>
-	<modExtensions>
-		<li Class="Apini.VatProperties">
-			<inputThingDef>Nectar_R</inputThingDef>
-			<outputThingDef>Honey_R</outputThingDef>
-			<maxCapacity>200</maxCapacity>
-			<fermentationModifier>3</fermentationModifier>
-			<!-- 1:4 ratio -->
-			<inputToOutputRatio>4</inputToOutputRatio>
-			<!-- Translations, point to custom translation lines. -->
-			<containsInputTranslation>ContainsNectar</containsInputTranslation>
-			<containsOutputTranslation>ContainsHoney</containsOutputTranslation>
-			<fermentedTranslation>FermentedHoney</fermentedTranslation>
-			<fermentationProgressTranslation>HoneyFermentationProgress</fermentationProgressTranslation>
-			<fermentationNonIdealTranslation>HoneyFermentationBarrelOutOfIdealTemperature</fermentationNonIdealTranslation>
-		</li>
-	</modExtensions>
-    <graphicData>
-      <texPath>Things/Building/Capsules/HoneyCapsule_Rushthorn</texPath>
-    </graphicData>
-  </ThingDef>
-
-  <ThingDef ParentName="VatBase">  <!-- Honey Vat (Wiserbud) -->
-    <defName>Vat_W</defName>
-    <label>Honey Capsule (Wiserbud)</label>
-    <description>A hexagonal container for creating honey from nectar.</description>
-    <thingClass>Apini.Building_FermentingVat</thingClass>
-	<modExtensions>
-		<li Class="Apini.VatProperties">
-			<inputThingDef>Nectar_W</inputThingDef>
-			<outputThingDef>Honey_W</outputThingDef>
-			<maxCapacity>200</maxCapacity>
-			<fermentationModifier>3</fermentationModifier>
-			<!-- 1:4 ratio -->
-			<inputToOutputRatio>4</inputToOutputRatio>
-			<!-- Translations, point to custom translation lines. -->
-			<containsInputTranslation>ContainsNectar</containsInputTranslation>
-			<containsOutputTranslation>ContainsHoney</containsOutputTranslation>
-			<fermentedTranslation>FermentedHoney</fermentedTranslation>
-			<fermentationProgressTranslation>HoneyFermentationProgress</fermentationProgressTranslation>
-			<fermentationNonIdealTranslation>HoneyFermentationBarrelOutOfIdealTemperature</fermentationNonIdealTranslation>
-		</li>
-	</modExtensions>
-    <graphicData>
-      <texPath>Things/Building/Capsules/HoneyCapsule_Wiserbud</texPath>
-    </graphicData>
-  </ThingDef>
-
-  <ThingDef ParentName="VatBase">  <!-- Honey Vat (Vigorbloom) -->
-    <defName>Vat_V</defName>
-    <label>Honey Capsule (Vigorbloom)</label>
-    <description>A hexagonal container for creating honey from nectar.</description>
-    <thingClass>Apini.Building_FermentingVat</thingClass>
-	<modExtensions>
-		<li Class="Apini.VatProperties">
-			<inputThingDef>Nectar_V</inputThingDef>
-			<outputThingDef>Honey_V</outputThingDef>
-			<maxCapacity>200</maxCapacity>
-			<fermentationModifier>3</fermentationModifier>
-			<!-- 1:4 ratio -->
-			<inputToOutputRatio>4</inputToOutputRatio>
-			<!-- Translations, point to custom translation lines. -->
-			<containsInputTranslation>ContainsNectar</containsInputTranslation>
-			<containsOutputTranslation>ContainsHoney</containsOutputTranslation>
-			<fermentedTranslation>FermentedHoney</fermentedTranslation>
-			<fermentationProgressTranslation>HoneyFermentationProgress</fermentationProgressTranslation>
-			<fermentationNonIdealTranslation>HoneyFermentationBarrelOutOfIdealTemperature</fermentationNonIdealTranslation>
-		</li>
-	</modExtensions>
-    <graphicData>
-      <texPath>Things/Building/Capsules/HoneyCapsule_Vigorbloom</texPath>
-    </graphicData>
-  </ThingDef>
-
-  <ThingDef ParentName="ApiniBuildingBase">  <!-- Honey Vat -->
-    <defName>HoneyVat</defName>
-    <label>honey vat</label>
-    <thingClass>Apini.Building_FermentingVat</thingClass>
-	<modExtensions>
-		<li Class="Apini.VatProperties">
-			<inputThingDef>Nectar</inputThingDef>
-			<outputThingDef>ApiniHoney</outputThingDef>
-			<maxCapacity>5000</maxCapacity>
-			<fermentationModifier>1</fermentationModifier>
-			<!-- 1:4 ratio -->
-			<inputToOutputRatio>10</inputToOutputRatio>
-			<!-- Translations, point to custom translation lines. -->
-			<containsInputTranslation>ContainsNectar</containsInputTranslation>
-			<containsOutputTranslation>ContainsHoney</containsOutputTranslation>
-			<fermentedTranslation>FermentedHoney</fermentedTranslation>
-			<fermentationProgressTranslation>HoneyFermentationProgress</fermentationProgressTranslation>
-			<fermentationNonIdealTranslation>HoneyFermentationBarrelOutOfIdealTemperature</fermentationNonIdealTranslation>
-		</li>
-	</modExtensions>
-    <graphicData>
-      <texPath>Things/Building/Capsules/HoneyVat</texPath>
-      <graphicClass>Graphic_Single</graphicClass>
-      <drawSize>(3,3)</drawSize>
-      <damageData>
-        <rect>(0,0.6,4,2.8)</rect>
-      </damageData>
-    </graphicData>
-    <minifiedDef>MinifiedThing</minifiedDef>
-    <altitudeLayer>Building</altitudeLayer>
-    <passability>PassThroughOnly</passability>
-    <fillPercent>0.45</fillPercent>
-    <pathCost>60</pathCost>
-    <building>
-    <isMealSource>true</isMealSource>
-    </building>
-    <statBases>
-      <WorkToBuild>3000</WorkToBuild>
-      <Mass>1500</Mass>
-      <MaxHitPoints>400</MaxHitPoints>
-      <Flammability>1.0</Flammability>
-    </statBases>
-    <size>(3,3)</size>
-    <description>A massive hexagonal container for creating honey from unflavored nectar.</description>
-    <costList>
-      <Pollen>250</Pollen>
-      <WoodLog>250</WoodLog>
-      <ApiniWax>300</ApiniWax>
-    </costList>
+		<tickerType>Rare</tickerType>
+		<rotatable>true</rotatable>
+		<constructEffect>ConstructWood</constructEffect>
+	</ThingDef>
+	<ThingDef ParentName="VatBase">
+		<!-- Honey Vat (Frostbell) -->
+		<defName>Vat_F</defName>
+		<label>Honey Capsule (Frostbell)</label>
+		<description>A hexagonal container for creating honey from nectar.</description>
+		<thingClass>Apini.Building_FermentingVat</thingClass>
+		<modExtensions>
+			<li Class="Apini.VatProperties">
+				<inputThingDef>Nectar_F</inputThingDef>
+				<outputThingDef>Honey_F</outputThingDef>
+				<maxCapacity>200</maxCapacity>
+				<fermentationModifier>3</fermentationModifier>
+				<!-- 1:4 ratio -->
+				<inputToOutputRatio>4</inputToOutputRatio>
+				<!-- Translations, point to custom translation lines. -->
+				<containsInputTranslation>ContainsNectar</containsInputTranslation>
+				<containsOutputTranslation>ContainsHoney</containsOutputTranslation>
+				<fermentedTranslation>FermentedHoney</fermentedTranslation>
+				<fermentationProgressTranslation>HoneyFermentationProgress</fermentationProgressTranslation>
+				<fermentationNonIdealTranslation>HoneyFermentationBarrelOutOfIdealTemperature</fermentationNonIdealTranslation>
+			</li>
+		</modExtensions>
+		<graphicData>
+			<texPath>Things/Building/Capsules/HoneyCapsule_Frostbell</texPath>
+		</graphicData>
+	</ThingDef>
+	<ThingDef ParentName="VatBase">
+		<!-- Honey Vat (Emberose) -->
+		<defName>Vat_E</defName>
+		<label>Honey Capsule (Emberose)</label>
+		<description>A hexagonal container for creating honey from nectar.</description>
+		<thingClass>Apini.Building_FermentingVat</thingClass>
+		<modExtensions>
+			<li Class="Apini.VatProperties">
+				<inputThingDef>Nectar_E</inputThingDef>
+				<outputThingDef>Honey_E</outputThingDef>
+				<maxCapacity>200</maxCapacity>
+				<fermentationModifier>3</fermentationModifier>
+				<!-- 1:4 ratio -->
+				<inputToOutputRatio>4</inputToOutputRatio>
+				<!-- Translations, point to custom translation lines. -->
+				<containsInputTranslation>ContainsNectar</containsInputTranslation>
+				<containsOutputTranslation>ContainsHoney</containsOutputTranslation>
+				<fermentedTranslation>FermentedHoney</fermentedTranslation>
+				<fermentationProgressTranslation>HoneyFermentationProgress</fermentationProgressTranslation>
+				<fermentationNonIdealTranslation>HoneyFermentationBarrelOutOfIdealTemperature</fermentationNonIdealTranslation>
+			</li>
+		</modExtensions>
+		<graphicData>
+			<texPath>Things/Building/Capsules/HoneyCapsule_Emberose</texPath>
+		</graphicData>
+	</ThingDef>
+	<ThingDef ParentName="VatBase">
+		<!-- Honey Vat (Metalily) -->
+		<defName>Vat_M</defName>
+		<label>Honey Capsule (Metalily)</label>
+		<description>A hexagonal container for creating honey from nectar.</description>
+		<thingClass>Apini.Building_FermentingVat</thingClass>
+		<modExtensions>
+			<li Class="Apini.VatProperties">
+				<inputThingDef>Nectar_M</inputThingDef>
+				<outputThingDef>Honey_M</outputThingDef>
+				<maxCapacity>200</maxCapacity>
+				<fermentationModifier>3</fermentationModifier>
+				<!-- 1:4 ratio -->
+				<inputToOutputRatio>4</inputToOutputRatio>
+				<!-- Translations, point to custom translation lines. -->
+				<containsInputTranslation>ContainsNectar</containsInputTranslation>
+				<containsOutputTranslation>ContainsHoney</containsOutputTranslation>
+				<fermentedTranslation>FermentedHoney</fermentedTranslation>
+				<fermentationProgressTranslation>HoneyFermentationProgress</fermentationProgressTranslation>
+				<fermentationNonIdealTranslation>HoneyFermentationBarrelOutOfIdealTemperature</fermentationNonIdealTranslation>
+			</li>
+		</modExtensions>
+		<graphicData>
+			<texPath>Things/Building/Capsules/HoneyCapsule_Metalily</texPath>
+		</graphicData>
+	</ThingDef>
+	<ThingDef ParentName="VatBase">
+		<!-- Honey Vat (Bardsong) -->
+		<defName>Vat_B</defName>
+		<label>Honey Capsule (Bardsong)</label>
+		<description>A hexagonal container for creating honey from nectar.</description>
+		<thingClass>Apini.Building_FermentingVat</thingClass>
+		<modExtensions>
+			<li Class="Apini.VatProperties">
+				<inputThingDef>Nectar_B</inputThingDef>
+				<outputThingDef>Honey_B</outputThingDef>
+				<maxCapacity>200</maxCapacity>
+				<fermentationModifier>3</fermentationModifier>
+				<!-- 1:4 ratio -->
+				<inputToOutputRatio>4</inputToOutputRatio>
+				<!-- Translations, point to custom translation lines. -->
+				<containsInputTranslation>ContainsNectar</containsInputTranslation>
+				<containsOutputTranslation>ContainsHoney</containsOutputTranslation>
+				<fermentedTranslation>FermentedHoney</fermentedTranslation>
+				<fermentationProgressTranslation>HoneyFermentationProgress</fermentationProgressTranslation>
+				<fermentationNonIdealTranslation>HoneyFermentationBarrelOutOfIdealTemperature</fermentationNonIdealTranslation>
+			</li>
+		</modExtensions>
+		<graphicData>
+			<texPath>Things/Building/Capsules/HoneyCapsule_Bardsong</texPath>
+		</graphicData>
+	</ThingDef>
+	<ThingDef ParentName="VatBase">
+		<!-- Honey Vat (Rushthorn) -->
+		<defName>Vat_R</defName>
+		<label>Honey Capsule (Rushthorn)</label>
+		<description>A hexagonal container for creating honey from nectar.</description>
+		<thingClass>Apini.Building_FermentingVat</thingClass>
+		<modExtensions>
+			<li Class="Apini.VatProperties">
+				<inputThingDef>Nectar_R</inputThingDef>
+				<outputThingDef>Honey_R</outputThingDef>
+				<maxCapacity>200</maxCapacity>
+				<fermentationModifier>3</fermentationModifier>
+				<!-- 1:4 ratio -->
+				<inputToOutputRatio>4</inputToOutputRatio>
+				<!-- Translations, point to custom translation lines. -->
+				<containsInputTranslation>ContainsNectar</containsInputTranslation>
+				<containsOutputTranslation>ContainsHoney</containsOutputTranslation>
+				<fermentedTranslation>FermentedHoney</fermentedTranslation>
+				<fermentationProgressTranslation>HoneyFermentationProgress</fermentationProgressTranslation>
+				<fermentationNonIdealTranslation>HoneyFermentationBarrelOutOfIdealTemperature</fermentationNonIdealTranslation>
+			</li>
+		</modExtensions>
+		<graphicData>
+			<texPath>Things/Building/Capsules/HoneyCapsule_Rushthorn</texPath>
+		</graphicData>
+	</ThingDef>
+	<ThingDef ParentName="VatBase">
+		<!-- Honey Vat (Wiserbud) -->
+		<defName>Vat_W</defName>
+		<label>Honey Capsule (Wiserbud)</label>
+		<description>A hexagonal container for creating honey from nectar.</description>
+		<thingClass>Apini.Building_FermentingVat</thingClass>
+		<modExtensions>
+			<li Class="Apini.VatProperties">
+				<inputThingDef>Nectar_W</inputThingDef>
+				<outputThingDef>Honey_W</outputThingDef>
+				<maxCapacity>200</maxCapacity>
+				<fermentationModifier>3</fermentationModifier>
+				<!-- 1:4 ratio -->
+				<inputToOutputRatio>4</inputToOutputRatio>
+				<!-- Translations, point to custom translation lines. -->
+				<containsInputTranslation>ContainsNectar</containsInputTranslation>
+				<containsOutputTranslation>ContainsHoney</containsOutputTranslation>
+				<fermentedTranslation>FermentedHoney</fermentedTranslation>
+				<fermentationProgressTranslation>HoneyFermentationProgress</fermentationProgressTranslation>
+				<fermentationNonIdealTranslation>HoneyFermentationBarrelOutOfIdealTemperature</fermentationNonIdealTranslation>
+			</li>
+		</modExtensions>
+		<graphicData>
+			<texPath>Things/Building/Capsules/HoneyCapsule_Wiserbud</texPath>
+		</graphicData>
+	</ThingDef>
+	<ThingDef ParentName="VatBase">
+		<!-- Honey Vat (Vigorbloom) -->
+		<defName>Vat_V</defName>
+		<label>Honey Capsule (Vigorbloom)</label>
+		<description>A hexagonal container for creating honey from nectar.</description>
+		<thingClass>Apini.Building_FermentingVat</thingClass>
+		<modExtensions>
+			<li Class="Apini.VatProperties">
+				<inputThingDef>Nectar_V</inputThingDef>
+				<outputThingDef>Honey_V</outputThingDef>
+				<maxCapacity>200</maxCapacity>
+				<fermentationModifier>3</fermentationModifier>
+				<!-- 1:4 ratio -->
+				<inputToOutputRatio>4</inputToOutputRatio>
+				<!-- Translations, point to custom translation lines. -->
+				<containsInputTranslation>ContainsNectar</containsInputTranslation>
+				<containsOutputTranslation>ContainsHoney</containsOutputTranslation>
+				<fermentedTranslation>FermentedHoney</fermentedTranslation>
+				<fermentationProgressTranslation>HoneyFermentationProgress</fermentationProgressTranslation>
+				<fermentationNonIdealTranslation>HoneyFermentationBarrelOutOfIdealTemperature</fermentationNonIdealTranslation>
+			</li>
+		</modExtensions>
+		<graphicData>
+			<texPath>Things/Building/Capsules/HoneyCapsule_Vigorbloom</texPath>
+		</graphicData>
+	</ThingDef>
+	<ThingDef ParentName="ApiniBuildingBase">
+		<!-- Honey Vat -->
+		<defName>HoneyVat</defName>
+		<label>honey vat</label>
+		<thingClass>Apini.Building_FermentingVat</thingClass>
+		<modExtensions>
+			<li Class="Apini.VatProperties">
+				<inputThingDef>Nectar</inputThingDef>
+				<outputThingDef>ApiniHoney</outputThingDef>
+				<maxCapacity>5000</maxCapacity>
+				<fermentationModifier>1</fermentationModifier>
+				<!-- 1:4 ratio -->
+				<inputToOutputRatio>10</inputToOutputRatio>
+				<!-- Translations, point to custom translation lines. -->
+				<containsInputTranslation>ContainsNectar</containsInputTranslation>
+				<containsOutputTranslation>ContainsHoney</containsOutputTranslation>
+				<fermentedTranslation>FermentedHoney</fermentedTranslation>
+				<fermentationProgressTranslation>HoneyFermentationProgress</fermentationProgressTranslation>
+				<fermentationNonIdealTranslation>HoneyFermentationBarrelOutOfIdealTemperature</fermentationNonIdealTranslation>
+			</li>
+		</modExtensions>
+		<graphicData>
+			<texPath>Things/Building/Capsules/HoneyVat</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<drawSize>(3,3)</drawSize>
+			<damageData>
+				<rect>(0,0.6,4,2.8)</rect>
+			</damageData>
+		</graphicData>
+		<minifiedDef>MinifiedThing</minifiedDef>
+		<altitudeLayer>Building</altitudeLayer>
+		<passability>PassThroughOnly</passability>
+		<fillPercent>0.45</fillPercent>
+		<pathCost>60</pathCost>
+		<building>
+			<isMealSource>true</isMealSource>
+		</building>
+		<statBases>
+			<WorkToBuild>3000</WorkToBuild>
+			<Mass>1500</Mass>
+			<MaxHitPoints>400</MaxHitPoints>
+			<Flammability>1.0</Flammability>
+		</statBases>
+		<size>(3,3)</size>
+		<description>A massive hexagonal container for creating honey from unflavored nectar.</description>
+		<costList>
+			<Pollen>250</Pollen>
+			<WoodLog>250</WoodLog>
+			<ApiniWax>300</ApiniWax>
+		</costList>
 		<comps>
-            <li Class="CompProperties_Forbiddable"/>
+			<li Class="CompProperties_Forbiddable"/>
 			<li Class="CompProperties_TemperatureRuinable">
 				<progressPerDegreePerTick>0.00001</progressPerDegreePerTick>
 				<minSafeTemperature>-20</minSafeTemperature>
 				<maxSafeTemperature>60</maxSafeTemperature>
 			</li>
 		</comps>
-    <tickerType>Rare</tickerType>
-    <rotatable>false</rotatable>
-    <constructEffect>ConstructWood</constructEffect>
-    <researchPrerequisites>
-      <li>HoneyRefining</li>
-    </researchPrerequisites>
-  </ThingDef>
-  
+		<tickerType>Rare</tickerType>
+		<rotatable>false</rotatable>
+		<constructEffect>ConstructWood</constructEffect>
+		<researchPrerequisites>
+			<li>HoneyRefining</li>
+		</researchPrerequisites>
+	</ThingDef>
 </Defs>

--- a/Common/Defs/ThingDefs_Races/Alien_Bee.xml
+++ b/Common/Defs/ThingDefs_Races/Alien_Bee.xml
@@ -98,6 +98,7 @@
 					<!--From Vanilla-->
 					<li>Apparel_CowboyHat</li>
 					<li>Apparel_BowlerHat</li>
+					<li>Apparel_TribalA</li>
 					<li>Apparel_TribalHeaddress</li>
 					<li>Apparel_Tuque</li>
 					<li>Apparel_WarMask</li>
@@ -190,6 +191,10 @@
 					<li MayRequire="VanillaExpanded.VAPPE">VAE_Headgear_Sunglasses</li>
 					<li MayRequire="VanillaExpanded.VAPPE">VAE_Headgear_Glasses</li>
 					<li MayRequire="VanillaExpanded.VAPPE">VAE_Headgear_ChefsToque</li>
+					<li MayRequire="VanillaExpanded.VAPPE">VAE_Apparel_Shorts</li>
+					<li MayRequire="VanillaExpanded.VAPPE">VAE_Apparel_Skirt</li>
+					<li MayRequire="VanillaExpanded.VAPPE">VAE_Apparel_Cape</li>
+					<li MayRequire="VanillaExpanded.VAPPE">VAE_Apparel_TribalKilt</li>
 					<!--From Vanilla Weapons Expanded-->
 					<li MayRequire="VanillaExpanded.VWEG">VWE_Apparel_DynamiteBelt</li>
 					<li MayRequire="VanillaExpanded.VWEG">VWE_Apparel_GrenadeEMPBelt</li>

--- a/Common/Defs/ThingDefs_Races/Race_Alien_Apini.xml
+++ b/Common/Defs/ThingDefs_Races/Race_Alien_Apini.xml
@@ -15,7 +15,7 @@
 			<MoveSpeed>4.9</MoveSpeed>
 			<Flammability>1.0</Flammability>
 			<CarryingCapacity>480</CarryingCapacity>
-			<MentalBreakThreshold>0.01</MentalBreakThreshold>
+			<MentalBreakThreshold>0.15</MentalBreakThreshold>
 			<ResearchSpeed>0.5</ResearchSpeed>
 			<MiningSpeed>0.5</MiningSpeed>
 			<SocialImpact>0.75</SocialImpact>

--- a/Common/Defs/ThingDefs_Races/Race_Alien_Azuri.xml
+++ b/Common/Defs/ThingDefs_Races/Race_Alien_Azuri.xml
@@ -15,7 +15,7 @@
 			<MoveSpeed>6</MoveSpeed>
 			<Flammability>1</Flammability>
 			<CarryingCapacity>200</CarryingCapacity>
-			<MentalBreakThreshold>0.1</MentalBreakThreshold>
+			<MentalBreakThreshold>0.12</MentalBreakThreshold>
 			<ResearchSpeed>0.25</ResearchSpeed>
 			<MiningSpeed>1.5</MiningSpeed>
 			<SocialImpact>0.25</SocialImpact>


### PR DESCRIPTION
Apitech table and synthesizer are no longer stuffed, making them less ugly
Apini and Azuri mental break thresholds have been increased, making mental breaks realistically possible with beeliens.
More Vanilla Expanded Apparel added to beelien whitelist.

fixes #61 
closes #70 
closes #71 